### PR TITLE
Update slogan to 'No crap, straight to the point apps with privacy by default'

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>The Byte Array | Privacy-friendly software</title>
-    <meta key="title" content="The Byte Array | Privacy-friendly software" property="og:title" />
+    <title>The Byte Array | No crap, straight to the point apps with privacy by default</title>
+    <meta key="title" content="The Byte Array | No crap, straight to the point apps with privacy by default" property="og:title" />
     <meta
-      content="Privacy-friendly developer tools, libraries, and products. Software that respects your data."
+      content="No crap, straight to the point apps with privacy by default. Built by The Byte Array."
       property="og:description"
     />
     <meta
-      content="Privacy-friendly developer tools, libraries, and products. Software that respects your data."
+      content="No crap, straight to the point apps with privacy by default. Built by The Byte Array."
       name="description"
     />
     <meta

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -172,7 +172,7 @@ export function Footer({ variant = "full" }: FooterProps) {
           <div className="mt-12 pt-8 border-t border-foreground/[0.08] text-xs text-foreground/45 text-center md:text-left">
             <p>&copy; {currentYear} The Byte Array. All rights reserved.</p>
             <p className="mt-1 text-foreground/35">
-              Privacy-friendly software.
+              No crap, straight to the point apps with privacy by default.
             </p>
           </div>
         </div>

--- a/src/config/about.ts
+++ b/src/config/about.ts
@@ -1,7 +1,7 @@
 export const aboutContent = {
   label: "About",
   headline: "The Byte Array",
-  lead: "Privacy-friendly software for developers and everyday users: tools, libraries, and products that minimize data collection and keep you in control.",
+  lead: "No crap, straight to the point apps with privacy by default. Tools, libraries, and products that keep you in control.",
   pillars: [
     {
       num: "01",

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -2,8 +2,7 @@ export type SiteConfig = typeof siteConfig;
 
 export const siteConfig = {
   name: "The Byte Array",
-  description:
-    "We build privacy-friendly software: developer tools, libraries, and products that respect your data and stay transparent.",
+  description: "No crap, straight to the point apps with privacy by default.",
   email: "contact@thebytearray.org",
   navItems: [
     { label: "About", href: "#about" },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -318,15 +318,16 @@ export default function IndexPage() {
               className="text-4xl sm:text-5xl md:text-6xl font-display text-foreground tracking-tight leading-[1.08] mb-6"
               variants={fadeInUp}
             >
-              Software that works
+              No crap, straight to the point apps with privacy by default
             </motion.h1>
 
             <motion.p
               className="text-base sm:text-lg text-foreground/55 max-w-lg mx-auto mb-10 leading-relaxed"
               variants={fadeInUp}
             >
-              Privacy-friendly tools, libraries, and products. Open source where
-              it helps the community; clear policies everywhere else.
+              Tools, libraries, and products that solve real problems without
+              trading away your privacy. Open source where it helps the
+              community; clear policies everywhere else.
             </motion.p>
 
             <motion.div


### PR DESCRIPTION
Resolves #13

Updates the website slogan from 'Privacy-friendly software' to the new brand slogan: No crap, straight to the point apps with privacy by default.

### Changes made:
- **index.html** - title, og:title, og:description, meta description
- **src/config/site.ts** - site description (used in footer)
- **src/config/about.ts** - about section lead text
- **src/pages/index.tsx** - hero heading and supporting paragraph
- **src/components/Footer.tsx** - footer tagline